### PR TITLE
refactor: support only queue URLs

### DIFF
--- a/src/pyinsole/ext/aws/base.py
+++ b/src/pyinsole/ext/aws/base.py
@@ -28,20 +28,3 @@ class _BotoProvider:
 
 class BaseSQSProvider(_BotoProvider):
     boto_service_name = "sqs"
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self._cached_queue_urls = {}
-
-    async def get_queue_url(self, queue):
-        if queue and (queue.startswith(("http://", "https://"))):
-            name = queue.split("/")[-1]
-            self._cached_queue_urls[name] = queue
-            queue = name
-
-        if queue not in self._cached_queue_urls:
-            async with self.get_client() as client:
-                response = await client.get_queue_url(QueueName=queue)
-                self._cached_queue_urls[queue] = response["QueueUrl"]
-
-        return self._cached_queue_urls[queue]

--- a/tests/src/pyinsole/ext/conftest.py
+++ b/tests/src/pyinsole/ext/conftest.py
@@ -50,7 +50,6 @@ class ClientContextCreator:
 @pytest.fixture
 def boto_client_sqs(queue_url, sqs_message):
     mock_client = mock.Mock()
-    mock_client.get_queue_url = mock.AsyncMock(return_value=queue_url)
     mock_client.delete_message = mock.AsyncMock()
     mock_client.receive_message = mock.AsyncMock(return_value=sqs_message)
     mock_client.send_message = mock.AsyncMock(return_value=sqs_send_message)

--- a/tests/src/pyinsole/ext/test_base.py
+++ b/tests/src/pyinsole/ext/test_base.py
@@ -1,4 +1,3 @@
-from unittest import mock
 
 import pytest
 
@@ -8,39 +7,6 @@ from pyinsole.ext.aws.base import BaseSQSProvider
 @pytest.fixture
 def base_sqs_provider():
     return BaseSQSProvider()
-
-
-@pytest.mark.asyncio
-async def test_get_queue_url(mock_boto_session_sqs, boto_client_sqs, base_sqs_provider):
-    with mock_boto_session_sqs as mock_sqs:
-        queue_url = await base_sqs_provider.get_queue_url("queue-name")
-        assert queue_url.startswith("https://")
-        assert queue_url.endswith("queue-name")
-
-        assert mock_sqs.called
-        assert boto_client_sqs.get_queue_url.called
-        assert boto_client_sqs.get_queue_url.call_args == mock.call(QueueName="queue-name")
-
-
-@pytest.mark.asyncio
-async def test_cache_get_queue_url(mock_boto_session_sqs, boto_client_sqs, base_sqs_provider):
-    with mock_boto_session_sqs:
-        await base_sqs_provider.get_queue_url("queue-name")
-        queue_url = await base_sqs_provider.get_queue_url("queue-name")
-        assert queue_url.startswith("https://")
-        assert queue_url.endswith("queue-name")
-        assert boto_client_sqs.get_queue_url.call_count == 1
-
-
-@pytest.mark.asyncio
-async def test_get_queue_url_when_queue_name_is_url(
-    mock_boto_session_sqs, boto_client_sqs, base_sqs_provider
-):
-    with mock_boto_session_sqs:
-        queue_url = await base_sqs_provider.get_queue_url("https://aws-whatever/queue-name")
-        assert queue_url.startswith("https://")
-        assert queue_url.endswith("queue-name")
-        assert boto_client_sqs.get_queue_url.call_count == 0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Discussed in https://github.com/pyinsole/pyinsole/discussions/9

<div type='discussions-op-text'>

<sup>Originally posted by **hartungstenio** November  6, 2024</sup>
As rotas SQS suportam receber tanto a URL como o nome da fila na inicialização. O problema é que todas as solicitações para o SQS precisam da URL.

Para contornar isso, existe uma lógica que faz uma solicitação a mais para o SQS para pegar a URL a partir do nome. Como isso tem um custo (não só de tempo de execução, mas financeiro também), existe também uma lógica que faz cache disso no provider.

Esse cache também está mal implementado. Ele está sendo feito no `provider`, mas cada rota instancia seu próprio `provider`. Na prática, temos um `dict` atuando como cache que sempre tem só um registro.

Poderíamos melhorar esse cache, mas me parece uma complexidade desnecessária, já que poderíamos suportar só a URL, como a própria AWS faz. Dessa forma, não precisaríamos nem da requisição para pegar a URL, nem da lógica de cache.</div>