### PR TITLE
fix: do not suppress CancelledError

### DIFF
--- a/src/pyinsole/dispatchers.py
+++ b/src/pyinsole/dispatchers.py
@@ -46,6 +46,7 @@ class Dispatcher(AbstractDispatcher):
         except asyncio.CancelledError:
             msg = '"{!r}" was cancelled, the message will not be acknowledged:\n{}\n'
             logger.warning(msg.format(route.handler, message))
+            raise
         except Exception as exc:
             logger.exception("%r", exc)  # noqa: TRY401
             exc_info = sys.exc_info()

--- a/tests/test_dispatchers.py
+++ b/tests/test_dispatchers.py
@@ -72,9 +72,9 @@ async def test_dispatch_message_task_cancel(route):
     dispatcher = Dispatcher([route])
     message = "message"
 
-    confirmation = await dispatcher._dispatch_message(message, route)  # noqa: SLF001
+    with pytest.raises(asyncio.CancelledError):
+        await dispatcher._dispatch_message(message, route)  # noqa: SLF001
 
-    assert confirmation is False
     route.deliver.assert_awaited_once_with(message)
 
 


### PR DESCRIPTION
#### What

- [x] Re-lança o CancelledError

<!-- Add screenshots here if necessary or use some
colums:

| First Column | Second Column| Third Column |
|--------------|--------------|--------------|
| picture-here | picture-here | picture-here |
-->

#### Why
Suprimir essa exceção faz com que o event loop nunca morra.


#### Reminders

- [x] My Pull Request is up to date with the main branch
- [ ] My PR build is 🟢
- [ ] This PR is not too big to be revised
- [ ] I added tests that cover success and error cases (if applicable)

<!-- #### Reminders

- PR title: type: <Title here>
  - Type is related to semantic release e.g. feat fix tests styles chore
- Tests have been added and are passing
- Lint is passing
- Dependencies are up to date.
- Review your own code before submitting the merge request.
- All env vars which are being used have been added to:
  - [`local.env`](local.env)
  - [`ci file`](.github/workflows/test.yaml)-->
