### PR TITLE
refactor: convert routes and providers to Context Managers

### DIFF
--- a/src/pyinsole/dispatchers.py
+++ b/src/pyinsole/dispatchers.py
@@ -3,6 +3,7 @@ import asyncio
 import logging
 import sys
 from collections.abc import Sequence
+from contextlib import AsyncExitStack
 from typing import Any
 
 from .routes import Route
@@ -112,22 +113,21 @@ class Dispatcher(AbstractDispatcher):
 
     async def dispatch(self, *, forever: bool = True):
         processing_queue: asyncio.Queue[tuple[Any, Route]] = asyncio.Queue(self.queue_size)
+        async with AsyncExitStack() as exit_stack:
+            for route in self.routes:
+                await exit_stack.enter_async_context(route)
 
-        async with asyncio.TaskGroup() as tg:
-            provider_task = tg.create_task(self._fetch_messages(processing_queue, tg, forever=forever))
-            consumer_tasks = [tg.create_task(self._consume_messages(processing_queue)) for _ in range(self.workers)]
+            async with asyncio.TaskGroup() as tg:
+                provider_task = tg.create_task(self._fetch_messages(processing_queue, tg, forever=forever))
+                consumer_tasks = [tg.create_task(self._consume_messages(processing_queue)) for _ in range(self.workers)]
 
-            async def join():
-                await provider_task
-                await processing_queue.join()
+                async def join():
+                    await provider_task
+                    await processing_queue.join()
 
-                for consumer_task in consumer_tasks:
-                    consumer_task.cancel()
+                    for consumer_task in consumer_tasks:
+                        consumer_task.cancel()
 
-                await asyncio.gather(*consumer_tasks, return_exceptions=True)
+                    await asyncio.gather(*consumer_tasks, return_exceptions=True)
 
-            tg.create_task(join())
-
-    def stop(self) -> None:
-        for route in self.routes:
-            route.stop()
+                tg.create_task(join())

--- a/src/pyinsole/providers.py
+++ b/src/pyinsole/providers.py
@@ -1,7 +1,14 @@
 import abc
+from contextlib import AbstractAsyncContextManager
 
 
-class AbstractProvider(abc.ABC):
+class AbstractProvider(AbstractAsyncContextManager):
+    """
+    Abstract message provider.
+
+    This class is used internally as a Context Manager.
+    """
+
     @abc.abstractmethod
     async def fetch_messages(self) -> list:
         """Return a sequence of messages to be processed.
@@ -20,9 +27,5 @@ class AbstractProvider(abc.ABC):
     async def message_not_processed(self, message):
         """Perform actions when a message was not processed."""
 
-    def stop(self):
-        """Stop the provider.
-
-        If needed, the provider should perform clean-up actions.
-        This method is called whenever we need to shutdown the provider.
-        """
+    async def __aexit__(self, exc_type, exc_value, traceback):
+        pass

--- a/tests/ext/test_providers.py
+++ b/tests/ext/test_providers.py
@@ -10,9 +10,10 @@ from pyinsole.ext.aws.providers import SQSProvider
 @pytest.mark.asyncio
 async def test_confirm_message(mock_boto_session_sqs, boto_client_sqs):
     with mock_boto_session_sqs:
-        provider = SQSProvider("queue-url")
         message = {"ReceiptHandle": "message-receipt-handle"}
-        await provider.confirm_message(message)
+
+        async with SQSProvider("queue-url") as provider:
+            await provider.confirm_message(message)
 
         assert boto_client_sqs.delete_message.call_args == mock.call(
             QueueUrl="queue-url",
@@ -24,43 +25,44 @@ async def test_confirm_message(mock_boto_session_sqs, boto_client_sqs):
 async def test_confirm_message_not_found(mock_boto_session_sqs, boto_client_sqs):
     error = ClientError(error_response={"ResponseMetadata": {"HTTPStatusCode": 404}}, operation_name="whatever")
     boto_client_sqs.delete_message.side_effect = error
-    with mock_boto_session_sqs:
-        provider = SQSProvider("queue-url")
-        message = {"ReceiptHandle": "message-receipt-handle-not-found"}
-        await provider.confirm_message(message)
+    message = {"ReceiptHandle": "message-receipt-handle-not-found"}
 
-        assert boto_client_sqs.delete_message.call_args == mock.call(
-            QueueUrl="queue-url",
-            ReceiptHandle="message-receipt-handle-not-found",
-        )
+    with mock_boto_session_sqs:
+        async with SQSProvider("queue-url") as provider:
+            await provider.confirm_message(message)
+
+    assert boto_client_sqs.delete_message.call_args == mock.call(
+        QueueUrl="queue-url",
+        ReceiptHandle="message-receipt-handle-not-found",
+    )
 
 
 @pytest.mark.asyncio
 async def test_confirm_message_unknown_error(mock_boto_session_sqs, boto_client_sqs):
     error = ClientError(error_response={"ResponseMetadata": {"HTTPStatusCode": 400}}, operation_name="whatever")
     boto_client_sqs.delete_message.side_effect = error
+    message = {"ReceiptHandle": "message-receipt-handle-not-found"}
     with mock_boto_session_sqs:
-        provider = SQSProvider("queue-name")
-        message = {"ReceiptHandle": "message-receipt-handle-not-found"}
-        with pytest.raises(ClientError):
-            await provider.confirm_message(message)
+        async with SQSProvider("queue-url") as provider:
+            with pytest.raises(ClientError):
+                await provider.confirm_message(message)
 
 
 @pytest.mark.asyncio
 async def test_fetch_messages(mock_boto_session_sqs, boto_client_sqs):
     options = {"WaitTimeSeconds": 5, "MaxNumberOfMessages": 10}
     with mock_boto_session_sqs:
-        provider = SQSProvider("queue-url", options=options)
-        messages = await provider.fetch_messages()
+        async with SQSProvider("queue-url", options=options) as provider:
+            messages = await provider.fetch_messages()
 
-        assert len(messages) == 1
-        assert messages[0]["Body"] == "test"
+    assert len(messages) == 1
+    assert messages[0]["Body"] == "test"
 
-        assert boto_client_sqs.receive_message.call_args == mock.call(
-            QueueUrl="queue-url",
-            WaitTimeSeconds=options.get("WaitTimeSeconds"),
-            MaxNumberOfMessages=options.get("MaxNumberOfMessages"),
-        )
+    assert boto_client_sqs.receive_message.call_args == mock.call(
+        QueueUrl="queue-url",
+        WaitTimeSeconds=options.get("WaitTimeSeconds"),
+        MaxNumberOfMessages=options.get("MaxNumberOfMessages"),
+    )
 
 
 @pytest.mark.asyncio
@@ -68,53 +70,50 @@ async def test_fetch_messages_returns_empty(mock_boto_session_sqs, boto_client_s
     options = {"WaitTimeSeconds": 5, "MaxNumberOfMessages": 10}
     boto_client_sqs.receive_message.return_value = {"Messages": []}
     with mock_boto_session_sqs:
-        provider = SQSProvider("queue-url", options=options)
-        messages = await provider.fetch_messages()
+        async with SQSProvider("queue-url", options=options) as provider:
+            messages = await provider.fetch_messages()
 
-        assert messages == []
-
-        assert boto_client_sqs.receive_message.call_args == mock.call(
-            QueueUrl="queue-url",
-            WaitTimeSeconds=options.get("WaitTimeSeconds"),
-            MaxNumberOfMessages=options.get("MaxNumberOfMessages"),
-        )
+    assert messages == []
+    assert boto_client_sqs.receive_message.call_args == mock.call(
+        QueueUrl="queue-url",
+        WaitTimeSeconds=options.get("WaitTimeSeconds"),
+        MaxNumberOfMessages=options.get("MaxNumberOfMessages"),
+    )
 
 
 @pytest.mark.asyncio
 async def test_fetch_messages_with_client_error(mock_boto_session_sqs, boto_client_sqs):
+    error = ClientError(error_response={"Error": {"Message": "unknown"}}, operation_name="whatever")
+    boto_client_sqs.receive_message.side_effect = error
     with mock_boto_session_sqs:
-        error = ClientError(error_response={"Error": {"Message": "unknown"}}, operation_name="whatever")
-        boto_client_sqs.receive_message.side_effect = error
-
-        provider = SQSProvider("queue-name")
-        with pytest.raises(ProviderError):
-            await provider.fetch_messages()
+        async with SQSProvider("queue-url") as provider:
+            with pytest.raises(ProviderError):
+                await provider.fetch_messages()
 
 
 @pytest.mark.asyncio
 async def test_fetch_messages_with_botocoreerror(mock_boto_session_sqs, boto_client_sqs):
+    error = BotoCoreError()
+    boto_client_sqs.receive_message.side_effect = error
     with mock_boto_session_sqs:
-        error = BotoCoreError()
-        boto_client_sqs.receive_message.side_effect = error
-
-        provider = SQSProvider("queue-name")
-        with pytest.raises(ProviderError):
-            await provider.fetch_messages()
+        async with SQSProvider("queue-url") as provider:
+            with pytest.raises(ProviderError):
+                await provider.fetch_messages()
 
 
 @pytest.mark.asyncio
 async def test_custom_visibility_timeout(mock_boto_session_sqs, boto_client_sqs):
     options = {"WaitTimeSeconds": 5, "MaxNumberOfMessages": 10, "VisibilityTimeout": 60}
     with mock_boto_session_sqs:
-        provider = SQSProvider("queue-url", options=options)
-        messages = await provider.fetch_messages()
+        async with SQSProvider("queue-url", options=options) as provider:
+            messages = await provider.fetch_messages()
 
-        assert len(messages) == 1
-        assert messages[0]["Body"] == "test"
+    assert len(messages) == 1
+    assert messages[0]["Body"] == "test"
 
-        assert boto_client_sqs.receive_message.call_args == mock.call(
-            QueueUrl="queue-url",
-            WaitTimeSeconds=options.get("WaitTimeSeconds"),
-            MaxNumberOfMessages=options.get("MaxNumberOfMessages"),
-            VisibilityTimeout=options.get("VisibilityTimeout"),
-        )
+    assert boto_client_sqs.receive_message.call_args == mock.call(
+        QueueUrl="queue-url",
+        WaitTimeSeconds=options.get("WaitTimeSeconds"),
+        MaxNumberOfMessages=options.get("MaxNumberOfMessages"),
+        VisibilityTimeout=options.get("VisibilityTimeout"),
+    )

--- a/tests/test_dispatchers.py
+++ b/tests/test_dispatchers.py
@@ -86,6 +86,8 @@ async def test_dispatch_providers(route):
     await dispatcher.dispatch(forever=False)
 
     dispatcher._dispatch_message.assert_awaited_once_with("message", route)  # noqa: SLF001
+    route.__aenter__.assert_awaited_once()
+    route.__aexit__.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -106,6 +108,11 @@ async def test_dispatch_providers_multiple_routes():
         any_order=True,
     )
 
+    route1.__aenter__.assert_awaited_once()
+    route1.__aexit__.assert_awaited_once()
+    route2.__aenter__.assert_awaited_once()
+    route2.__aexit__.assert_awaited_once()
+
 
 @pytest.mark.asyncio
 async def test_dispatch_providers_with_error(route):
@@ -116,12 +123,5 @@ async def test_dispatch_providers_with_error(route):
         await dispatcher.dispatch(forever=False)
 
     assert exc_info.value.subgroup(ValueError) is not None
-
-
-def test_dispatcher_stop(route):
-    route.stop = mock.Mock()
-    dispatcher = Dispatcher([route])
-
-    dispatcher.stop()
-
-    assert route.stop.called
+    route.__aenter__.assert_awaited_once()
+    route.__aexit__.assert_awaited_once()


### PR DESCRIPTION
#### What

- [x] Transforma providers e rotas em Context managers
- [x] Deixa engatilhada a possibilidade de passar o cliente do SQS na mão.

<!-- Add screenshots here if necessary or use some
colums:

| First Column | Second Column| Third Column |
|--------------|--------------|--------------|
| picture-here | picture-here | picture-here |
-->

#### Why

Cada solicitação para o SQS instanciava um novo client, chamava uma função, e derrubava esse client. Isso parece ser um grande desperdício de recursos.

Essa foi a forma que eu encontrei para deixar esse client "persistente". Só ter um client enquanto a rota estiver ativa. Para o usuário final, nada muda.


#### Reminders

- [x] My Pull Request is up to date with the main branch
- [ ] My PR build is 🟢
- [ ] This PR is not too big to be revised
- [ ] I added tests that cover success and error cases (if applicable)

<!-- #### Reminders

- PR title: type: <Title here>
  - Type is related to semantic release e.g. feat fix tests styles chore
- Tests have been added and are passing
- Lint is passing
- Dependencies are up to date.
- Review your own code before submitting the merge request.
- All env vars which are being used have been added to:
  - [`local.env`](local.env)
  - [`ci file`](.github/workflows/test.yaml)-->
