### PR TITLE
perf: use a single provider task per route

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,10 @@
+{
+    "recommendations": [
+        "charliermarsh.ruff",
+        "editorconfig.editorconfig",
+        "github.vscode-github-actions",
+        "ms-python.python",
+        "panekj.even-betterer-toml",
+        "redhat.vscode-yaml"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "python.testing.pytestArgs": [
+        "tests"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
+}


### PR DESCRIPTION
#### What

- [x] Cria só uma task por rota.

<!-- Add screenshots here if necessary or use some
colums:

| First Column | Second Column| Third Column |
|--------------|--------------|--------------|
| picture-here | picture-here | picture-here |
-->

#### Why
Isso deve reduzir um pouco o uso de recursos.


#### Reminders

- [x] My Pull Request is up to date with the main branch
- [ ] My PR build is 🟢
- [ ] This PR is not too big to be revised
- [ ] I added tests that cover success and error cases (if applicable)

<!-- #### Reminders

- PR title: type: <Title here>
  - Type is related to semantic release e.g. feat fix tests styles chore
- Tests have been added and are passing
- Lint is passing
- Dependencies are up to date.
- Review your own code before submitting the merge request.
- All env vars which are being used have been added to:
  - [`local.env`](local.env)
  - [`ci file`](.github/workflows/test.yaml)-->
