### PR TITLE
fix: contextvars friendly

### DIFF
--- a/src/pyinsole/__init__.py
+++ b/src/pyinsole/__init__.py
@@ -1,4 +1,8 @@
+import logging
+
 from .managers import Manager
 from .routes import Route
 
 __all__ = ["Manager", "Route"]
+
+logging.getLogger(__name__).addHandler(logging.NullHandler())


### PR DESCRIPTION
#### What

- [x] Cria uma nova task para cada mensagem.
- [x] Configura um handler padrão para logs, conforme [recomendação](logging.getLogger('boto3').addHandler(NullHandler())).

<!-- Add screenshots here if necessary or use some
colums:

| First Column | Second Column| Third Column |
|--------------|--------------|--------------|
| picture-here | picture-here | picture-here |
-->

#### Why

Usando um simples `await` como estava, usamos sempre o mesmo contexto. Isso é um problema para quem usar `contextvars`, já que as variáveis seriam compartilhadas entre todas as mensagens.

Criando uma nova task, garantimos que cada mensagem tenha seu contexto, sem mudar muito a lógica geral.


#### Reminders

- [x] My Pull Request is up to date with the main branch
- [x] My PR build is 🟢
- [x] This PR is not too big to be revised
- [x] I added tests that cover success and error cases (if applicable)

<!-- #### Reminders

- PR title: type: <Title here>
  - Type is related to semantic release e.g. feat fix tests styles chore
- Tests have been added and are passing
- Lint is passing
- Dependencies are up to date.
- Review your own code before submitting the merge request.
- All env vars which are being used have been added to:
  - [`local.env`](local.env)
  - [`ci file`](.github/workflows/test.yaml)-->
